### PR TITLE
gx: update go-multihash

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-0.4.9: QmZD7kdgd6eiBCvNbyvsFQ11h3ainoCJpJRbecDx3CPcbZ
+0.4.10: Qmf82zCaYV8bkztRRoGwwSHVkaYtP2UKBnhpjJz1uFGJjQ

--- a/package.json
+++ b/package.json
@@ -15,33 +15,33 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmXY77cVe7rVRQXZZQRioukUM7aRW3BTcAgJe12MCtb3Ji",
+      "hash": "QmW8s4zTsUoX1Q6CeYxVKPyqSKbF7H1YDUyTostBtZ8DaG",
       "name": "go-multiaddr",
-      "version": "1.2.4"
-    },
-    {
-      "author": "whyrusleeping",
-      "hash": "QmXYjuNuxVzXKJCfWasQk1RqkhVLDM9jtUKhqc2WPQmFSB",
-      "name": "go-libp2p-peer",
-      "version": "2.2.0"
-    },
-    {
-      "author": "whyrusleeping",
-      "hash": "QmQBB2dQLmQHJgs2gqZ3iqL2XiuCtUCvXzWt5kMXDf5Zcr",
-      "name": "go-maddr-filter",
-      "version": "1.1.4"
-    },
-    {
-      "author": "whyrusleeping",
-      "hash": "Qme2XMfKbWzzYd92YvA1qnFMe3pGDR86j5BcFtx4PwdRvr",
-      "name": "go-libp2p-transport",
-      "version": "2.2.9"
-    },
-    {
-      "author": "whyrusleeping",
-      "hash": "QmSU6eubNdhXjFBJBSksTp8kv8YRub8mGAPv8tVJHmL2EU",
-      "name": "go-ipfs-util",
       "version": "1.2.5"
+    },
+    {
+      "author": "whyrusleeping",
+      "hash": "QmWNY7dV54ZDYmTA1ykVdwNCqC11mpU4zSUp6XDpLTH9eG",
+      "name": "go-libp2p-peer",
+      "version": "2.2.1"
+    },
+    {
+      "author": "whyrusleeping",
+      "hash": "QmcrNvQBZkpbT7zLcGyjdPCiCHLVtaYeg4UVUH7XLfWJWy",
+      "name": "go-maddr-filter",
+      "version": "1.1.5"
+    },
+    {
+      "author": "whyrusleeping",
+      "hash": "QmQGRkVSA5vTXt9WpJ6nBGnrvq9zRNsfjoNPq8uQrhnBoq",
+      "name": "go-libp2p-transport",
+      "version": "2.2.10"
+    },
+    {
+      "author": "whyrusleeping",
+      "hash": "QmPsAfmDBnZN3kZGSuNwvCNDZiHneERSKmRcFyG3UkvcT3",
+      "name": "go-ipfs-util",
+      "version": "1.2.6"
     }
   ],
   "gxVersion": "0.9.1",
@@ -49,6 +49,6 @@
   "license": "",
   "name": "go-libp2p-interface-conn",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "0.4.9"
+  "version": "0.4.10"
 }
 


### PR DESCRIPTION
Depends on:

- https://github.com/libp2p/go-libp2p-peer/pull/20
- https://github.com/libp2p/go-libp2p-secio/pull/23
- https://github.com/multiformats/go-multiaddr/pull/61
- https://github.com/multiformats/go-multiaddr-net/pull/33
- https://github.com/whyrusleeping/iptb/pull/37
- https://github.com/whyrusleeping/mafmt/pull/7
- https://github.com/libp2p/go-libp2p-peerstore/pull/18
- https://github.com/ipfs/go-ipfs-util/pull/6
- https://github.com/libp2p/go-libp2p-transport/pull/25
- https://github.com/libp2p/go-peerstream/pull/19
- https://github.com/libp2p/go-libp2p-loggables/pull/14
- https://github.com/libp2p/go-tcp-transport/pull/17
- https://github.com/libp2p/go-maddr-filter/pull/4
- https://github.com/libp2p/go-ws-transport/pull/28
- https://github.com/libp2p/go-addr-util/pull/9
- https://github.com/ipfs/go-cid/pull/39
- https://github.com/libp2p/go-testutil/pull/15


This PR with gx updates has been created using gx-workspace: https://github.com/ipfs/gx-workspace